### PR TITLE
Add simple internal gradle plugin via buildSrc for downloading  models

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
-    id("org.jetbrains.kotlin.jvm") version "1.3.61"
+    id("org.jetbrains.kotlin.jvm")
 
     // Apply the application plugin to add support for building a CLI application.
     application
@@ -12,6 +12,9 @@ plugins {
 
     // Bintray
     id("com.jfrog.bintray") version "1.8.4"
+
+    // model downloader
+    id("model-downloader-plugin")
 }
 
 tasks.withType<KotlinCompile> {
@@ -78,4 +81,9 @@ bintray {
             name = libraryVersion
         }
     }
+}
+
+tasks.named<io.mattmoore.tensorflow.model.plugin.DownloadModelTask>("downloadModel") {
+    sourceUrl = "https://storage.googleapis.com/download.tensorflow.org/models/tflite/posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite"
+    target = "models/123_posenet_model.tflite"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    `java-gradle-plugin`
+    `kotlin-dsl`
+    `kotlin-dsl-precompiled-script-plugins`
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+}
+
+kotlinDslPluginOptions {
+    experimentalWarning.set(false)
+}
+
+group = "io.mattmoore.tensorflow.plugin"
+version = "1.0"
+
+dependencies {
+    compileOnly(gradleApi())
+    implementation("com.squareup.okhttp3:okhttp:4.2.2")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+}
+
+gradlePlugin {
+    plugins {
+        register("ModelDownloader") {
+            id = "model-downloader-plugin"
+            implementationClass = "io.mattmoore.tensorflow.model.plugin.TensorflowModelDownloaderPlugin"
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/mattmoore/tensorflow/plugin/gradle/DownloadModelTask.kt
+++ b/buildSrc/src/main/kotlin/io/mattmoore/tensorflow/plugin/gradle/DownloadModelTask.kt
@@ -1,0 +1,42 @@
+package io.mattmoore.tensorflow.model.plugin
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.BufferedSink
+import okio.buffer
+import okio.sink
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class DownloadModelTask : DefaultTask() {
+
+    @get:Input
+    lateinit var sourceUrl: String
+
+    @OutputFile
+    lateinit var target: String
+
+    init {
+        group = "prepare" // This will be the group name for your task.
+        description = "Download Tensorflow model file"
+    }
+
+    @TaskAction // Marks a function as the action to run when the task is executed.
+    fun run() {
+        val client = OkHttpClient()
+
+        val request = Request.Builder().url(sourceUrl).build()
+        val response = client.newCall(request).execute()
+        if (response.isSuccessful) {
+            val sink: BufferedSink = File("${project.projectDir}/$target").sink().buffer()
+            sink.writeAll(response.body!!.source())
+            sink.close()
+        } else {
+            throw GradleException("Error downloaded file at $sourceUrl with code ${response.code}")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/mattmoore/tensorflow/plugin/gradle/TensorflowModelDownloaderPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/mattmoore/tensorflow/plugin/gradle/TensorflowModelDownloaderPlugin.kt
@@ -1,0 +1,14 @@
+package io.mattmoore.tensorflow.model.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+
+open class TensorflowModelDownloaderPlugin : Plugin<Project> {
+    override fun apply(project: Project): Unit = project.run {
+        tasks.register<DownloadModelTask>("downloadModel") {
+            sourceUrl = "https://storage.googleapis.com/download.tensorflow.org/models/tflite/posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite"
+            target = "models/posenet_model.tflite"
+        }
+    }
+}


### PR DESCRIPTION
Add a new task named **downloadModel**.

You can define your own source and folder destination like this
```
tasks.named<io.mattmoore.tensorflow.model.plugin.DownloadModelTask>("downloadModel") {
    sourceUrl = "https://storage.googleapis.com/download.tensorflow.org/models/tflite/posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite"
    target = "models/123_posenet_model.tflite"
}
```